### PR TITLE
Corretta equazione rappresentazione coordinate e errori battitura

### DIFF
--- a/chapters/oscillatore.tex
+++ b/chapters/oscillatore.tex
@@ -368,7 +368,7 @@ Notiamo che lo stato fondamentale è anch'esso uno stato coerente, corrispondent
 \section{Soluzioni dell'equazione di Schr\"odinger}
 In una dimensione, con un potenziale della forma $V(q)=\frac12m\omega^2q^2$, l'equazione di Schr\"odinger per la funzione d'onda $\psi$ nella base della posizione è
 \begin{equation}
-	\frac{\hbar^2}{2m}\psi''(q)+\bigg(E-\frac12m\omega q^2\bigg)\psi(q)=0.
+	\frac{\hbar^2}{2m}\psi''(q)+\bigg(E-\frac12m\omega^2 q^2\bigg)\psi(q)=0.
 	\label{eq:schrodinger-oscillatore-1d}
 \end{equation}
 In questa forma però risulta difficile da risolvere, anche perch\'e non conosciamo il valore di $E$.
@@ -376,13 +376,13 @@ Per evitarla usiamo, come abbiamo già fatto per ricavare lo spettro dell'hamilt
 Nella base delle coordinate, abbiamo per uno stato $\ket{\psi}$ (con la funzione d'onda $\psi(q)=\braket{q}{\psi}$)
 \begin{multline}
 	\bra{q}\op a\ket{\psi}=\bra{q}\frac{\op p-im\omega\op q}{\sqrt{2m\hbar\omega}}\ket{\psi}=\frac1{\sqrt{2m\hbar\omega}}(\bra{q}\op p\ket{\psi}-im\omega\bra{q}\op q\ket{\psi})=\\
-	=\frac1{\sqrt{2m\hbar\omega}}\bigg[-ih\drv{\psi}{q}(q)-im\omega q\psi(q)\bigg]
+	=\frac1{\sqrt{2m\hbar\omega}}\bigg[-i\hbar\drv{\psi}{q}(q)-im\omega q\psi(q)\bigg]
 \end{multline}
 Possiamo dunque rappresentare $\op a$ come l'operatore in $L^2(\R)$
 \begin{equation}
 	f(q)\mapsto-\frac{i}{\sqrt{2}}\bigg[\sqrt{\frac{\hbar}{m\omega}}\drv{f}{q}(q)+\sqrt{\frac{m\omega}{\hbar}}qf(q)\bigg].
 \end{equation}
-Possiamo semplificare il tutto con un cambio di variabili: poniamo $y=\big(\frac{m\omega}{\hbar})^{-\frac12}q$, da cui $\drv{}{q}=\drv{y}{q}\drv{}{y}=\big(\frac{m\omega}{\hbar})^{-\frac12}\drv{}{q}$, ottenendo
+Possiamo semplificare il tutto con un cambio di variabili: poniamo $y=\big(\frac{m\omega}{\hbar})^{-\frac12}q$, da cui $\drv{}{q}=\drv{y}{q}\drv{}{y}=\big(\frac{m\omega}{\hbar})^{-\frac12}\drv{}{y}$, ottenendo
 \begin{equation}
 	\op a=-\frac{i}{\sqrt{2}}\bigg(\drv{}{y}+y\bigg)
 \end{equation}

--- a/chapters/rappresentazioni.tex
+++ b/chapters/rappresentazioni.tex
@@ -293,7 +293,7 @@ Nel caso di più gradi di libertà, gli operatori di moltiplicazione $q_i$ e di 
 
 Torniamo all'equazione di Schr\"odinger $\op H\ket{E}=E\ket{E}$: una particella soggetta ad un potenziale $V(\vec q)$ ha un'hamiltoniana $H(\vec q,\vec p)=\frac1{2m}\vec p^2+V(\vec q)$, a cui è associato l'operatore $\op H=\frac1{2m}\sum_{i=1}^3\op p_i^2+V(\op{\vec q})$, dunque risulta
 \begin{equation}
-	\bra{q}\op H\ket{E}=\bigg[-\frac1{2m}\sum_{i=1}^3\bigg(-i\hbar\drp{}{q_i}\bigg)^2+V(\vec q)\bigg]\braket{q}{E}=E\braket{q}{E}
+	\bra{q}\op H\ket{E}=\bigg[\frac1{2m}\sum_{i=1}^3\bigg(-i\hbar\drp{}{q_i}\bigg)\cdot\bigg(-i\hbar\drp{}{q_i}\bigg)+V(\vec q)\bigg]\braket{q}{E}=E\braket{q}{E}
 	\label{eq:hamiltoniano-coordinate}
 \end{equation}
 da cui ricaviamo l'equazione differenziale alle derivate parziali, del secondo ordine,


### PR DESCRIPTION
Cambiato il quadrato dell'operatore p nella rappresentazione delle coordinate con il prodotto dell'operatore per se stesso.
In ogni caso pur mantenedo la tua notazione mi pare che ci sia un errore di segno.
Come prodotto ho messo il classico \cdot, non so se sia corretto secondo i tuoi standard.
